### PR TITLE
fix: remove unused default value for upper parameter in to_chars function

### DIFF
--- a/src/core.mbt
+++ b/src/core.mbt
@@ -510,11 +510,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
 }
 
 ///|
-fn to_chars(
-  v : FloatingDecimal64,
-  sign : Bool,
-  upper~ : Bool = false,
-) -> String {
+fn to_chars(v : FloatingDecimal64, sign : Bool, upper : Bool) -> String {
   // Step 5: Print the decimal representation.
   let result = FixedArray::make(25, Byte::default())
   let mut index : Int = 0
@@ -679,7 +675,7 @@ pub fn ryu_to_string(val : Double, upper~ : Bool = false) -> String {
     }
     None => v = d2d(ieeeMantissa, ieeeExponent.reinterpret_as_uint())
   }
-  to_chars(v, ieeeSign, upper~)
+  to_chars(v, ieeeSign, upper)
 }
 
 ///|

--- a/src/core.mbt
+++ b/src/core.mbt
@@ -16,6 +16,7 @@
 // This is a fork of the ryu crate adjusted to comply to the ECMAScript number-to-string algorithm,
 
 // This File fork from https://github.com/oonbitlang/core/tree/main/double/internal/ryu
+
 ///|
 fn pow5bits(e : Int) -> Int {
   ((e * 1217359).reinterpret_as_uint() >> 19).reinterpret_as_int() + 1
@@ -116,7 +117,7 @@ fn mulShiftAll64(
   m : UInt64,
   mul : (UInt64, UInt64),
   j : Int,
-  mmShift : Bool
+  mmShift : Bool,
 ) -> (UInt64, UInt64, UInt64) {
   let m = m << 1
   let (lo, tmp) = umul128(m, mul.0)
@@ -512,7 +513,7 @@ fn d2d(ieeeMantissa : UInt64, ieeeExponent : UInt) -> FloatingDecimal64 {
 fn to_chars(
   v : FloatingDecimal64,
   sign : Bool,
-  upper~ : Bool = false
+  upper~ : Bool = false,
 ) -> String {
   // Step 5: Print the decimal representation.
   let result = FixedArray::make(25, Byte::default())
@@ -622,7 +623,7 @@ fn to_chars(
 ///|
 fn d2d_small_int(
   ieeeMantissa : UInt64,
-  ieeeExponent : Int
+  ieeeExponent : Int,
 ) -> FloatingDecimal64? {
   let m2 : UInt64 = (1UL << gDOUBLE_MANTISSA_BITS) | ieeeMantissa
   let e2 : Int = ieeeExponent - gDOUBLE_BIAS - gDOUBLE_MANTISSA_BITS

--- a/src/ryu.mbt
+++ b/src/ryu.mbt
@@ -64,6 +64,7 @@ fn mulShift_mod1e9(m : UInt64, mul : Array[UInt64], j : Int) -> Int {
 }
 
 // Returns the number of decimal digits in v, which must not contain more than 9 digits.
+
 ///|
 fn decimalLength9(v : Int) -> Int {
   // Function precondition: v is not a 10-digit number.
@@ -125,7 +126,8 @@ test "db2string4" {
   )
 }
 
-// TODO: roundUp 
+// TODO: roundUp
+
 ///|
 test "db2string5" {
   inspect(
@@ -139,7 +141,7 @@ fn write_digits(
   array : FixedArray[Byte],
   start : Int,
   len : Int,
-  digits : Int
+  digits : Int,
 ) -> Unit {
   let mut idx = start + len - 1
   let mut digits = digits
@@ -161,7 +163,7 @@ test "write_digits" {
 fn write_nine_digits(
   array : FixedArray[Byte],
   start : Int,
-  digits : Int
+  digits : Int,
 ) -> Unit {
   write_digits(array, start, 9, digits)
 }
@@ -171,7 +173,7 @@ fn write_chars(
   array : FixedArray[Byte],
   start : Int,
   len : Int,
-  char : Byte
+  char : Byte,
 ) -> Unit {
   let mut idx = start
   for _ in 0..<len {
@@ -185,7 +187,7 @@ fn write_decimal_digits(
   array : FixedArray[Byte],
   start : Int,
   len : Int,
-  digits : Int
+  digits : Int,
 ) -> Unit {
   let mut idx = start + len
   let mut digits = digits
@@ -387,7 +389,7 @@ pub fn ryu_to_string_precision(val : Double, precision~ : Int = 17) -> String {
 pub fn ryu_to_string_exp(
   val : Double,
   precision~ : Int = 17,
-  upper~ : Bool = false
+  upper~ : Bool = false,
 ) -> String {
   let mut precision = precision
   let result = FixedArray::make(25, Byte::default())
@@ -601,10 +603,7 @@ pub fn ryu_to_string_exp(
 
 ///|
 test "ryu_to_string_exp" {
-  inspect(
-    ryu_to_string_exp(12345.123, precision=3),
-    content="1.235e+04",
-  )
+  inspect(ryu_to_string_exp(12345.123, precision=3), content="1.235e+04")
 }
 
 ///|

--- a/src/ryu.mbti
+++ b/src/ryu.mbti
@@ -1,11 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "BigOrangeQWQ/ryu"
 
 // Values
-fn ryu_to_string(Double, upper~ : Bool = ..) -> String
+fn ryu_to_string(Double, upper? : Bool) -> String
 
-fn ryu_to_string_exp(Double, precision~ : Int = .., upper~ : Bool = ..) -> String
+fn ryu_to_string_exp(Double, precision? : Int, upper? : Bool) -> String
 
-fn ryu_to_string_precision(Double, precision~ : Int = ..) -> String
+fn ryu_to_string_precision(Double, precision? : Int) -> String
+
+// Errors
 
 // Types and methods
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes compiler warning 0032 about an unused default value.
The to_chars function's upper parameter was declared with a default value
of `false`, but all calls to this function explicitly provide the upper
argument, making the default value unused.

- Changed `upper~ : Bool = false` to `upper : Bool` in to_chars function
- Updated the call site to pass the parameter directly instead of using `upper~`
- All tests continue to pass
- No functional changes to the public API